### PR TITLE
Refactor UserManager to use 'this' pointer for user_data access in se…

### DIFF
--- a/src/UserManager.cpp
+++ b/src/UserManager.cpp
@@ -106,7 +106,7 @@ bool UserManager::signup(const std::string &username, const std::string &email, 
     vault_manager.generate_user_vault(
         kek_bytes,
         opks,
-        user_data,
+        this->user_data,
         identity_keys,
         signed_prekey
     );
@@ -126,17 +126,17 @@ void UserManager::handle_saving_remote_user_data() {
 }
 
 void UserManager::setUser(const UserModel& user) {
-    user_data = user;
+    this->user_data = user;
 }
 void UserManager::setUser(const std::string& username, const std::string& email) {
-    user_data.username = username;
-    user_data.email = email;
+    this->user_data.username = username;
+    this->user_data.email = email;
 }
 
 std::vector<uint8_t> UserManager::get_decrypted_kek() const {
     // Get the current KEK model and user UUID
-    auto user_id = user_data.id;
-    auto kek_model = db().get_all<KEKModel>(where(c(&KEKModel::user_id) == user_id)).front();
+    // auto user_id = user_data.id;
+    auto kek_model = db().get_all<KEKModel>(where(c(&KEKModel::user_id) == this->user_data.id)).front();
     const std::vector<uint8_t>& master_key = MasterKey::instance().get();
 
     // Decrypt the KEK using KekService


### PR DESCRIPTION
This pull request updates the `UserManager` class in `src/UserManager.cpp` to consistently use the `this` pointer when accessing the `user_data` member. This change improves code clarity and ensures proper member variable access within the class.

### Code clarity improvements:

* Updated `vault_manager.generate_user_vault` to use `this->user_data` instead of `user_data` for accessing the member variable.
* Modified `setUser` methods to use `this->user_data` for setting `username` and `email` fields, ensuring explicit access to the member variable.
* Changed `get_decrypted_kek` method to use `this->user_data.id` for retrieving the user ID, improving readability and consistency.…tUser and get_decrypted_kek methods