### PR TITLE
Refactor generate_nonce method in CryptoUtils; move definition to hea…

### DIFF
--- a/src/RemoteUserManager.cpp
+++ b/src/RemoteUserManager.cpp
@@ -12,6 +12,10 @@ RemoteUserManager::RemoteUserManager() {
     // TODO: implement constructor
 }
 
+RemoteUserManager::~RemoteUserManager() {
+
+}
+
 nlohmann::json RemoteUserManager::save() {
     // TODO: implement save logic
     // This should serialize user_data and keys_data to a string format (e.g., JSON)

--- a/src/RemoteUserManager.h
+++ b/src/RemoteUserManager.h
@@ -15,7 +15,7 @@
 class RemoteUserManager:DataManager {
 public:
     RemoteUserManager();
-    virtual ~RemoteUserManager() override = default;
+    virtual ~RemoteUserManager() override;
 protected:
     // Setters use reference args to avoid slicing
     // and set the pointers to the remote user, keys, and KEK data

--- a/src/UserManager.cpp
+++ b/src/UserManager.cpp
@@ -198,9 +198,6 @@ void UserManager::changePassword(const std::string& user_uuid, const std::string
     }
     db().update(new_kek_model);
 }
-void UserManager::handle_saving_remote_user_data() {
-
-}
 
 void UserManager::setUser(const UserModel& user) {
     this->user_data = user;

--- a/src/UserManager.cpp
+++ b/src/UserManager.cpp
@@ -21,6 +21,10 @@ UserManager::UserManager() {
     user_data = UserModel();
 }
 
+UserManager::~UserManager() {
+    MasterKey::instance().clear();
+}
+
 KEKModel UserManager::get_local_kek(int user_id) const {
     auto kek_models = db().get_all<KEKModel>(where(c(&KEKModel::user_id) == user_id));
     if (kek_models.empty()) {

--- a/src/UserManager.h
+++ b/src/UserManager.h
@@ -17,7 +17,6 @@ public:
 
     bool signup(const std::string &username, const std::string &email, const std::string &password);
     void changePassword(const std::string& user_uuid, const std::string& old_password, const std::string &new_password);
-    void handle_saving_remote_user_data();
 
     //function overloading
     void setUser(const UserModel& user);

--- a/src/UserManager.h
+++ b/src/UserManager.h
@@ -12,13 +12,14 @@
 class UserManager: RemoteUserManager {
 public:
     UserManager();
+    ~UserManager() override;
     void login(const std::string& username, const std::string& password);
 
     bool signup(const std::string &username, const std::string &email, const std::string &password);
     void changePassword(const std::string& user_uuid, const std::string& old_password, const std::string &new_password);
-    bool checkKek();
     void handle_saving_remote_user_data();
 
+    //function overloading
     void setUser(const UserModel& user);
     void setUser(const std::string& username, const std::string& email);
     std::vector<uint8_t> get_decrypted_kek(const std::vector<uint8_t> &master_key) const;


### PR DESCRIPTION
This pull request introduces destructor implementations for the `RemoteUserManager` and `UserManager` classes, replacing default destructors and adding cleanup logic where necessary. Additionally, a minor refactor was performed in the `UserManager` class.

### Destructor Implementation and Cleanup:

* [`src/RemoteUserManager.cpp`](diffhunk://#diff-3f080e2b6f0e189bbab581a80710651b16eb03d89fdbad246712119cf06dfeacR15-R18): Added an explicit destructor for `RemoteUserManager`.
* [`src/RemoteUserManager.h`](diffhunk://#diff-2ce585f87fe3e13d5bab1f8b38efade8020a668ef2957b9e704e17966e765b60L18-R18): Replaced the default destructor for `RemoteUserManager` with an explicit declaration.
* [`src/UserManager.cpp`](diffhunk://#diff-a5f440c185ecf636796e334e237993433798acf5c48d2d0234fef72d754df220R24-R27): Implemented an explicit destructor for `UserManager`, which clears the `MasterKey` singleton to ensure proper cleanup.
* [`src/UserManager.h`](diffhunk://#diff-05e67fe9b73e90039f415d9f87547fbce13b71648f5e5dbf3b315d16bce4b5afR15-R22): Added an explicit destructor declaration for `UserManager`.

### Minor Refactor:

* [`src/UserManager.h`](diffhunk://#diff-05e67fe9b73e90039f415d9f87547fbce13b71648f5e5dbf3b315d16bce4b5afR15-R22): Removed the unused `checkKek` method and added comments to clarify function overloading for `setUser`.